### PR TITLE
Day 1, task 1

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,11 @@ document.addEventListener("turbo:before-render", (event) => {
   prevPath = window.location.pathname;
   event.detail.render = async (prevEl, newEl) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
-    morphdom(prevEl, newEl);
+    morphdom(prevEl, newEl, {
+      onBeforeElUpdated: (fromEl, toEl) => {
+        return !(fromEl.isEqualNode(toEl) || fromEl.hasAttribute("data-turbo-morph-permanent"));
+      },
+    });
   };
 
   if (document.startViewTransition) {

--- a/app/views/albums/_aside.html.erb
+++ b/app/views/albums/_aside.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (album: nil) -%>
-<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent" => true}, "transition-name" => "aside" do %>
+<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-morph-permanent" => true}, "transition-name" => "aside" do %>
   <% next unless album %>
   <div transition-id="<%= album.id %>">
     <div class="album-info">

--- a/app/views/shared/_player.html.erb
+++ b/app/views/shared/_player.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (track:, station: nil) -%>
-<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent>
+<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-morph-permanent>
   <% if track %>
     <div class="player--timeline">
       <div class="player--timeline-progress" style="width:11%;"></div>


### PR DESCRIPTION
# День 1

## Проблема

Turbo заново добавляет (монтирует) постоянные элементы в DOM-дерево после каждой отрисовки. Это приводит, например, к перезапуску CSS анимаций и потере фокуса. В частности, в нашем приложении при каждой навигации анимация прогресса плеера (player-emulation) начинается заново.

## Задание

Необходимо перенести логику перманентных элементов из Turbo в morphdom и сделать так, чтобы элементы остались в DOM-дереве, если нет необходимости их перерисовывать.

## Критерии выполнения

- [x] Прогресс-бар плеера не прерывается при навигации по приложению
- [x] Прогресс-бар стартует заново при смене трека в плеера

## Советы по реализации

Используйте опцию onBeforeElUpdated в параметрах morphdom.
https://github.com/patrick-steele-idem/morphdom
