### PR TITLE
Add Load more feature

### DIFF
--- a/app/controllers/artists/tracks_controller.rb
+++ b/app/controllers/artists/tracks_controller.rb
@@ -1,0 +1,26 @@
+class Artists::TracksController < ApplicationController
+  def index
+    show_next_page = all_tracks.count > page * 5
+
+    render partial: "tracks",
+           locals: { artist:, tracks:, current_page: page, show_next_page: }
+  end
+  
+  private
+
+  def tracks
+    all_tracks.popularity_ordered.limit(5).offset(5 * page)
+  end
+
+  def all_tracks
+    @all_tracks ||= artist.tracks
+  end
+
+  def page
+    params[:page].to_i+1 || 1
+  end
+  
+  def artist
+    @artist ||= Artist.find(params[:artist_id])
+  end
+end

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -16,17 +16,10 @@
   </div>
 </div>
 
-<hr class="my-4">
-
-<h2 class="mt-4 text-header-2">Popular</h2>
-<ul class="tracks mt-2">
-  <%= render tracks, enqueueble: true %>
-  <li class="track">
-    <span class="track--number"></span>
-    <a href="#" class="text-secondary hover:text-primary transition-colors">Load more</a>
-  </li>
-</ul>
-
 <hr class="my-4"/>
 
+<h2 class="mt-4 mb-2 text-header-2">Popular</h2>
+<%= render partial: "artists/tracks/tracks", locals: {artist:, tracks:} %>
+
+<hr class="my-4"/>
 <%= render partial: "discography", locals: {artist:, albums:} %>

--- a/app/views/artists/tracks/_tracks.html.erb
+++ b/app/views/artists/tracks/_tracks.html.erb
@@ -1,0 +1,17 @@
+<%# locals: (artist:, tracks:, current_page: 0, show_next_page: true) -%>
+<%= turbo_frame_tag "tracks-#{artist.id}-#{current_page}", target: "_top" do %>
+  <ul class="tracks">
+    <% tracks.each_with_index do |track, i| %>
+      <%= render partial: "tracks/track", locals: {track:, track_counter: current_page * 5 + i, enqueueble: true} %>
+    <% end %>
+  </ul>
+
+  <% if show_next_page %>
+    <%= turbo_frame_tag "tracks-#{artist.id}-#{current_page+1}", target: "_top" do %>
+      <li class="track">
+        <span class="track--number"></span>
+        <%= link_to 'Load more', artist_tracks_path(artist, page: current_page), class: "text-secondary hover:text-primary transition-colors", data: { "turbo-frame" => "_self" } %>
+      </li>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -12,7 +12,7 @@
       <%= track.title %>
     <% end %>
   <% else %>
-    <%= link_to track.title, params.to_unsafe_h.merge(track_id: track.id), class: "track--title" %>
+    <%= link_to track.title, artist_path(track.album.artist, track_id: track.id), class: "track--title" %>
   <% end %>
   <% if current_user %>
     <span class="track--actions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   post "sign_up", to: "registrations#create"
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
-  resources :artists, only: [:show]
+  resources :artists, only: [:show] do
+    resources :tracks, only: [:index], controller: "artists/tracks"
+  end
   resources :albums, only: [:show] do
     patch :play, on: :member
   end


### PR DESCRIPTION
## Задание
Необходимо реализовать подгрузку следующих 5 треков при клике на "Load more" на странице артиста. Использовать Turbo Frames.

## Критерии выполнения
Работает, как в примере.

## Дисклеймер
Совсем не нравится костыль с оборачиванием ссылки в турбофрейм и заменой его содержимого на следующие 5 песен и новый фрейм с ссылкой. Эдакая матрёшка на выходе.
Но не пришло в голову ничего более элегантного при текущих ограничениях на средства реализации.
В реальном проекте для пагинации скорее всего был бы гем, а не костыльные самостоятельные расчёты.

Ещё происходит небольшая ахинея при выборе для проигрывания песни из тех, что были подгружены позднее. Не знаю, нужно ли тратить время на исправление и входит ли это в текущее задание. 