### PR TITLE
Add lazy load to all tracks by artist

### DIFF
--- a/app/controllers/artists/tracks_controller.rb
+++ b/app/controllers/artists/tracks_controller.rb
@@ -1,0 +1,32 @@
+class Artists::TracksController < ApplicationController
+  PER_PAGE = 25
+
+  def index
+    next_page = all_tracks.count > current_page * PER_PAGE ? current_page + 1 : nil
+
+    if turbo_frame_request?
+      render partial: "tracks",
+             locals: { artist:, tracks:, current_page:, next_page:  }
+    else
+      render :index, locals: { artist:, tracks:, current_page:, next_page:  }
+    end
+  end
+  
+  private
+
+  def tracks
+    all_tracks.popularity_ordered.limit(PER_PAGE).offset(PER_PAGE * current_page)
+  end
+
+  def all_tracks
+    @all_tracks ||= artist.tracks
+  end
+
+  def current_page
+    params[:page].to_i || 0
+  end
+  
+  def artist
+    @artist ||= Artist.find(params[:artist_id])
+  end
+end

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,7 +18,11 @@
 
 <hr class="my-4">
 
-<h2 class="mt-4 text-header-2">Popular</h2>
+<div class="mt-4 flex justify-between">
+  <h2 class="text-header-2">Popular</h2>
+  <%= link_to "See all", artist_tracks_path(artist), class: "text-secondary hover:text-primary transition-colors" %>
+</div>
+
 <ul class="tracks mt-2">
   <%= render tracks, enqueueble: true %>
   <li class="track">

--- a/app/views/artists/tracks/_tracks.html.erb
+++ b/app/views/artists/tracks/_tracks.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (artist:, tracks:, current_page: 0, next_page: 1) -%>
+<%= turbo_frame_tag "tracks-#{artist.id}-#{current_page}", target: "_top" do %>
+  <ul class="tracks">
+    <% tracks.each_with_index do |track, i| %>
+      <%= render partial: "tracks/track", locals: {track:, track_counter: current_page * 25 + i, enqueueble: true} %>
+    <% end %>
+  </ul>
+
+  <% if next_page %>
+    <%= turbo_frame_tag "tracks-#{artist.id}-#{next_page}", target: "_top",
+                        src: artist_tracks_path(artist, page: next_page), loading: "lazy" %>
+  <% end %>
+<% end %>

--- a/app/views/artists/tracks/index.html.erb
+++ b/app/views/artists/tracks/index.html.erb
@@ -1,0 +1,24 @@
+<div class="artist-header">
+  <div class="artist-image">
+    <% if artist.cover.attached? %>
+      <%= image_tag artist.cover %>
+    <% end %>
+  </div>
+  <div class="artist-info">
+    <div class="flex items-center">
+      <h1 class="text-header-2"><%= artist.name %></h1>
+    </div>
+    <div>
+      <% artist.tags.each do |tag| %>
+        <span class="meta"><%= tag %></span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<hr class="my-4"/>
+
+<h2 class="mt-4 text-header-2">All Tracks</h2>
+<ul class="tracks mt-2">
+  <%= render partial: "tracks", locals: { artist:, tracks:} %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   post "sign_up", to: "registrations#create"
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
-  resources :artists, only: [:show]
+  resources :artists, only: [:show] do
+    resources :tracks, only: [:index], controller: "artists/tracks"
+  end
   resources :albums, only: [:show] do
     patch :play, on: :member
   end


### PR DESCRIPTION
## Задание
Необходимо добавить новую страницу со всеми треками артиста с ленивой подгрузкой треков при прокрутке (aka infinite scroll pagination). Использовать только Turbo Frames.

## Критерии выполнения
Напротив "Popular tracks" на странице артиста необходимо добавить ссылку "See all".
При клике на неё открывается страница /artists/:id/tracks, на которой выводится список всех треков.
Работает как на примере.